### PR TITLE
Update to openSUSE Leap 15.2

### DIFF
--- a/download-mingw-rpm.py
+++ b/download-mingw-rpm.py
@@ -162,7 +162,7 @@ def GetOptions():
 
   # Options specifiying download repository
   default_project = "windows:mingw:win32"
-  default_repository = "openSUSE_11.4"
+  default_repository = "openSUSE_Leap_15.2"
   default_repo_url = "http://download.opensuse.org/repositories/PROJECT/REPOSITORY/"
   repoOptions = OptionGroup(parser, "Specify download repository")
   repoOptions.add_option("-p", "--project", dest="project", default=default_project,


### PR DESCRIPTION
Update openSUSE version.

This is used for an installer of glade 

https://gitlab.gnome.org/GNOME/glade/-/blob/master/build/mingw-w64/nsis_make_installer.sh#L89

but current version do not exists anymore.